### PR TITLE
fix(build): update build script to use local TypeScript

### DIFF
--- a/speako-koreanlearner/package.json
+++ b/speako-koreanlearner/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "npx tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview"
   },


### PR DESCRIPTION
This commit updates the build script in package.json to use locally installed TypeScript via npx.

Changed:
- Modified "build" script from "tsc -b && vite build" to "npx tsc -b && vite build"

This fixes the CI/CD build failure where the TypeScript compiler (tsc) was not found in the build environment. Using npx ensures that we consistently use the project's TypeScript version instead of relying on global installations, improving build reliability across different environments.