### PR TITLE
feat: wav -> mp3 변환 함수 추가

### DIFF
--- a/data/utils.py
+++ b/data/utils.py
@@ -1,8 +1,15 @@
 import json
 from typing import List, Dict, Any
+from pydub import AudioSegment
 
 
 def save_json(data: List[Dict[str, Any]], output_path: str = "label_data.json") -> None:
     with open(output_path, "w", encoding="utf-8") as f:
         json.dump(data, f, ensure_ascii=False, indent=2)
     print(f"✅ JSON 파일 저장 완료: {output_path}")
+
+
+def convert_wav_to_mp3(input_path, output_path, ffmpeg_path):
+    AudioSegment.converter = ffmpeg_path
+    sound = AudioSegment.from_wav(input_path)
+    sound.export(output_path, format="mp3", bitrate="320k")


### PR DESCRIPTION
사용자 녹음 파일(wav)을 mp3로 변환하는 기능 추가
환경에 따라 ffmpeg 경로를 파라미터로 받아 직접 지정할 수 있도록 구성
데이터 전처리나 음성 파일 관리 시 재사용 가능하도록 utils에 포함