### PR TITLE
feat: 볼륨 정규화하는 process_audio  함수 구현

### DIFF
--- a/data/audio_preprocessing.py
+++ b/data/audio_preprocessing.py
@@ -1,0 +1,19 @@
+from pydub import AudioSegment
+import librosa
+import soundfile as sf
+import io
+
+def process_audio(input_file: str, output_file: str) -> None:
+    audio = AudioSegment.from_wav(input_file)
+    audio = audio.set_channels(1)
+    audio = audio.set_frame_rate(22050) # 샘플링 레이트 조정
+
+    normalized_audio = audio.normalize() # 볼륨 정규화
+
+    with io.BytesIO() as buffer:
+        normalized_audio.export(buffer, format="wav")
+        buffer.seek(0)
+
+        y, sr = librosa.load(buffer, sr=None, mono=True)
+
+        sf.write(output_file, y, sr)


### PR DESCRIPTION
- 입력된 WAV 파일을 모노로 변환하고, 샘플링 레이트를 22050Hz로 맞춤
- pydub을 이용해 오디오 볼륨 정규화
- librosa로 로드하여 최종 WAV 파일로 저장